### PR TITLE
fix: run prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds prepare script in order to generate types required for typescript. This is not required usually on published packages but we need it since we are on a fork